### PR TITLE
fis issue with nogo areas nomop areas

### DIFF
--- a/src/main/kotlin/de/konqi/roborockbridge/bridge/dto/MapDataForPublish.kt
+++ b/src/main/kotlin/de/konqi/roborockbridge/bridge/dto/MapDataForPublish.kt
@@ -16,7 +16,9 @@ data class MapDataForPublish(
     val path: List<Coordinate<Float>>?,
     val gotoPath: List<Coordinate<Float>>?,
     val predictedPath: List<Coordinate<Float>>?,
-    val virtualWalls: List<List<Coordinate<Float>>>
+    val virtualWalls: List<List<Coordinate<Float>>>,
+    val noGoAreas: List<List<Coordinate<Float>>>,
+    val noMoppingArea: List<List<Coordinate<Float>>>
 ) {
     operator fun get(name: String): Any? {
         return fieldNames[name]?.invoke(this)
@@ -41,7 +43,9 @@ data class MapDataForPublish(
             gotoPath = payload.gotoPath?.points,
             path = payload.path?.points,
             predictedPath = payload.predictedPath?.points,
-            virtualWalls = payload.virtualWalls?.zones?.map { listOf(it.start, it.end) } ?: listOf()
+            virtualWalls = payload.virtualWalls?.zones?.map { listOf(it.start, it.end) } ?: listOf(),
+            noGoAreas = payload.noGoAreas?.areas?.map { listOf(it.first, it.second, it.third, it.forth) } ?: listOf(),
+            noMoppingArea = payload.noGoAreas?.areas?.map { listOf(it.first, it.second, it.third, it.forth) } ?: listOf()
         )
     }
 }

--- a/src/main/kotlin/de/konqi/roborockbridge/remote/mqtt/map/dto/MapDataArea.kt
+++ b/src/main/kotlin/de/konqi/roborockbridge/remote/mqtt/map/dto/MapDataArea.kt
@@ -39,7 +39,7 @@ data class MapDataArea<T>(val numberOfAreas: UShort, val areas: List<MapDataArea
         fun fromMapDataSection(data: MapDataSection): MapDataArea<UShort> {
             val numberOfAreas = data.header.getShort(8).toUShort()
             val areas = List(numberOfAreas.toInt()) { index ->
-                MapDataAreaVertices.fromRaw(data.body.slice(index * 8, 8).order(ByteOrder.LITTLE_ENDIAN))
+                MapDataAreaVertices.fromRaw(data.body.slice(index * 16, 16).order(ByteOrder.LITTLE_ENDIAN))
             }
 
             return MapDataArea(numberOfAreas = numberOfAreas, areas = areas)

--- a/src/test/kotlin/de/konqi/roborockbridge/bridge/MapDataForPublishTest.kt
+++ b/src/test/kotlin/de/konqi/roborockbridge/bridge/MapDataForPublishTest.kt
@@ -20,8 +20,14 @@ class MapDataForPublishTest {
             listOf(Coordinate(1.2f, 2.3f), Coordinate(3.4f, 4.5f)),
             listOf(Coordinate(6.7f, 7.8f), Coordinate(8.9f, 9.0f))
         ),
-        noGoAreas = listOf(),
-        noMoppingArea = listOf()
+        noGoAreas = listOf(
+            listOf(Coordinate(323.72f, 249.24f), Coordinate(323.72f, 270.24f),Coordinate(383.88f, 270.24f), Coordinate(383.88f, 249.24f)),
+            listOf(Coordinate(3315.64f, 238.8f), Coordinate(315.64f, 256.86f),Coordinate(352.22f, 256.86f), Coordinate(352.22f, 238.8f))
+        ),
+        noMoppingArea = listOf(
+            listOf(Coordinate(323.72f, 249.24f), Coordinate(323.72f, 270.24f),Coordinate(383.88f, 270.24f), Coordinate(383.88f, 249.24f)),
+            listOf(Coordinate(3315.64f, 238.8f), Coordinate(315.64f, 256.86f),Coordinate(352.22f, 256.86f), Coordinate(352.22f, 238.8f))
+        )
     )
 
     @Test
@@ -50,7 +56,9 @@ class MapDataForPublishTest {
                 "path",
                 "predictedPath",
                 "gotoPath",
-                "virtualWalls"
+                "virtualWalls",
+                "noGoAreas",
+                "noMoppingArea"
             )
         )
     }

--- a/src/test/kotlin/de/konqi/roborockbridge/bridge/MapDataForPublishTest.kt
+++ b/src/test/kotlin/de/konqi/roborockbridge/bridge/MapDataForPublishTest.kt
@@ -19,7 +19,9 @@ class MapDataForPublishTest {
         virtualWalls = listOf(
             listOf(Coordinate(1.2f, 2.3f), Coordinate(3.4f, 4.5f)),
             listOf(Coordinate(6.7f, 7.8f), Coordinate(8.9f, 9.0f))
-        )
+        ),
+        noGoAreas = listOf(),
+        noMoppingArea = listOf()
     )
 
     @Test


### PR DESCRIPTION
When I added nogo areas to my map (I have a Roborock Qrevo Master) I got the following error:

```
2024-08-03T16:44:18.179+02:00  INFO 749731 --- [all: rrb_SzUs2l] d.k.r.remote.mqtt.RoborockMqtt           : Lambda: New message for topic 'rr/m/o/4EUZXHZXIzF8TWaCO6eXNn/5bd9676a/3nuRxpUimbqlq0IGJdJzGU' 0
2024-08-03T16:44:18.185+02:00 ERROR 749731 --- [all: rrb_SzUs2l] d.k.r.remote.mqtt.RoborockMqtt           : Error while handling message from topic rr/m/o/4EUZXHZXIzF8TWaCO6eXNn/5bd9676a/3nuRxpUimbqlq0IGJdJzGU

java.lang.IndexOutOfBoundsException: null
        at java.base/java.nio.Buffer.checkIndex(Buffer.java:749) ~[na:na]
        at java.base/java.nio.HeapByteBuffer.getShort(HeapByteBuffer.java:387) ~[na:na]
        at de.konqi.roborockbridge.remote.mqtt.map.dto.MapDataAreaVertices$Companion.fromRaw(MapDataArea.kt:21) ~[!/:0.0.7-SNAPSHOT]
        at de.konqi.roborockbridge.remote.mqtt.map.dto.MapDataArea$Companion.fromMapDataSection(MapDataArea.kt:42) ~[!/:0.0.7-SNAPSHOT]
        at de.konqi.roborockbridge.remote.mqtt.map.MapDataPayload$Companion.fromRawBytes(MapDataPayload.kt:54) ~[!/:0.0.7-SNAPSHOT]
        at de.konqi.roborockbridge.remote.mqtt.map.Protocol301$Companion.decryptAndDecode(MapDataWrapper.kt:40) ~[!/:0.0.7-SNAPSHOT]
        at de.konqi.roborockbridge.remote.mqtt.map.Protocol301$Companion.access$decryptAndDecode(MapDataWrapper.kt:24) ~[!/:0.0.7-SNAPSHOT]
        at de.konqi.roborockbridge.remote.mqtt.map.Protocol301.<init>(MapDataWrapper.kt:22) ~[!/:0.0.7-SNAPSHOT]
        at de.konqi.roborockbridge.remote.mqtt.map.Protocol301Binary.decryptAndDecode(MapDataWrapper.kt:50) ~[!/:0.0.7-SNAPSHOT]
        at de.konqi.roborockbridge.remote.mqtt.MessageDecoder.readProtocol301Body(MessageDecoder.kt:167) ~[!/:0.0.7-SNAPSHOT]
        at de.konqi.roborockbridge.remote.mqtt.MessageDecoder.decode(MessageDecoder.kt:90) ~[!/:0.0.7-SNAPSHOT]
        at de.konqi.roborockbridge.remote.mqtt.RoborockMqtt.handleMessage(RoborockMqtt.kt:167) ~[!/:0.0.7-SNAPSHOT]
        at de.konqi.roborockbridge.remote.mqtt.RoborockMqtt.subscribe$lambda$3(RoborockMqtt.kt:159) ~[!/:0.0.7-SNAPSHOT]
        at org.eclipse.paho.client.mqttv3.internal.CommsCallback.deliverMessage(CommsCallback.java:511) ~[org.eclipse.paho.client.mqttv3-1.2.5.jar!/:na]
        at org.eclipse.paho.client.mqttv3.internal.CommsCallback.handleMessage(CommsCallback.java:417) ~[org.eclipse.paho.client.mqttv3-1.2.5.jar!/:na]
        at org.eclipse.paho.client.mqttv3.internal.CommsCallback.run(CommsCallback.java:214) ~[org.eclipse.paho.client.mqttv3-1.2.5.jar!/:na]
        at java.base/java.lang.Thread.run(Thread.java:840) ~[na:na]
```

The issue here was, that MapDataAreaVertices expects 4 coordinates for each area, while it was called like this:
```
MapDataAreaVertices.fromRaw(data.body.slice(index * 8, 8).order(ByteOrder.LITTLE_ENDIAN))
```
Since here only 8 bytes are extracted and passed, only 2 coordinates are available. To fix this I sliced the data with 16 bytes to get the third and the fourth. As this was never used when publishing I added it there tool